### PR TITLE
Fixes pre-renewal duet dancing (#7160)

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5205,7 +5205,7 @@ void status_calc_state( struct block_list *bl, struct status_change *sc, std::bi
 				  || (sc->data[SC_FEAR] && sc->data[SC_FEAR]->val2 > 0)
 				  || (sc->data[SC_SPIDERWEB] && sc->data[SC_SPIDERWEB]->val1)
 				  || (sc->data[SC_HIDING] && (bl->type != BL_PC || (pc_checkskill(BL_CAST(BL_PC,bl),RG_TUNNELDRIVE) <= 0)))
-				  || (sc->data[SC_DANCING] && sc->data[SC_DANCING]->val4 && (
+				  || (sc->data[SC_DANCING] && (
 #ifndef RENEWAL
 						!sc->data[SC_LONGING] ||
 #endif


### PR DESCRIPTION
* Fixes #7134.
* Resolves an issue where duet songs resulted in the partner not being able to move when canceling the song early.
Thanks to @hnomkeng!

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
